### PR TITLE
Fix Gatsby path prefix linking to other pages

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -1,6 +1,10 @@
 import type { GatsbyConfig } from "gatsby";
 
 const config: GatsbyConfig = {
+  // Because the site is hosted on GitHub Pages as a project page
+  // https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/
+  pathPrefix: "/blazerbots",
+
   siteMetadata: {
     title: `blazerbots`,
     siteUrl: `https://www.yourdomain.tld`,


### PR DESCRIPTION
# What
- configuring `pathPrefix` option according to docs: https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/
- No need to change CI/CD process as it already builds with `pathPrefix` if present: https://github.com/OHSBlazerbots/blazerbots/blob/f1ec374/.github/workflows/gatsby-deploy.yml#L78-L81

# Why
- docs explicitly mention this as a solution for GitHub pages

# Testing
- I built the site locally (with `--path-prefix` option) and when served, it injected the prefix. While the link fails, it created the right path for production
    - ![image](https://github.com/OHSBlazerbots/blazerbots/assets/6364480/386704b4-78c7-4065-9e02-b8d8054815e3)
- At the same time this does not break local development via `npm run develop`
