### PR TITLE
fix: Navbar.brand link to index page

### DIFF
--- a/src/components/NavBar/navBar.module.css
+++ b/src/components/NavBar/navBar.module.css
@@ -6,6 +6,11 @@
   display: inline-block;
 }
 
+.linkNavBrand {
+  text-decoration: none;
+  display: inline-block;
+}
+
 .linkDefault:hover {
   color: black;
 }

--- a/src/components/NavBar/navBar.tsx
+++ b/src/components/NavBar/navBar.tsx
@@ -13,16 +13,18 @@ function NavBar() {
   return ( 
     <Navbar className={navBackground} expand="lg" variant="dark">
       <Container>
-        <Navbar.Brand href="/">
-            <img
-              alt=""
-              src={blackLogo}
-              width="30"
-              height="30"
-              className="d-inline-block align-top"
-            />{' '}
-            BlazerBots 3807
-        </Navbar.Brand>
+        <Link to="/" className="link-no-style">
+          <Navbar.Brand>
+              <img
+                alt=""
+                src={blackLogo}
+                width="30"
+                height="30"
+                className="d-inline-block align-top"
+              />{' '}
+              BlazerBots 3807
+          </Navbar.Brand>
+        </Link>
         <Navbar.Toggle aria-controls="basic-navbar-nav" />
         <Navbar.Collapse id="basic-navbar-nav" className="justify-content-end">
           <Nav className="navbar navbar-light" >

--- a/src/components/NavBar/navBar.tsx
+++ b/src/components/NavBar/navBar.tsx
@@ -5,7 +5,7 @@ import Navbar from "react-bootstrap/Navbar";
 import NavDropdown from "react-bootstrap/NavDropdown";
 import blackLogo from "../../images/logo192_black.png";
 import { Link } from "gatsby";
-import { navBackground, linkDefault, linkActive, dropDefault } from './navBar.module.css';
+import { navBackground, linkDefault, linkActive, linkNavBrand, dropDefault } from './navBar.module.css';
 
 const stopClickPropagation:React.MouseEventHandler = event => event.stopPropagation();
 
@@ -13,7 +13,7 @@ function NavBar() {
   return ( 
     <Navbar className={navBackground} expand="lg" variant="dark">
       <Container>
-        <Link to="/" className="link-no-style">
+        <Link to="/" className={linkNavBrand} >
           <Navbar.Brand>
               <img
                 alt=""


### PR DESCRIPTION
# What
- fixes the link at the Navbar Brand element

# Why
- To take advantage of [Gatsby automatic preloading](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-link/#link-drives-gatsbys-fast-page-navigation)
- In production, the link currently goes to `https://ohsblazerbots.github.io/` rather than `https://ohsblazerbots.github.io/blazerbots`

# Testing
- [x] when local developing Navbar Brand links to index page
- [x] when local developing Navbar Brand link does not cause page refresh
- [x] when building locally with `` option Navbar Brand links to `localhost:port/blazerbots`