### PR TITLE
Feat/Arrange Sponsor's in grid

### DIFF
--- a/src/components/BasePage/BasePage.module.css
+++ b/src/components/BasePage/BasePage.module.css
@@ -1,10 +1,18 @@
+.pageContainer {
+  min-height: 100vh;
+  display:flex;
+  flex-direction:column;
+}
+
 .header {
   text-align: center;
   padding-top: 10px;
   padding-bottom: 10px;
 }
 
-.page {
+.pageArticle {
+  flex: 1;
+
   width: 60%;
   margin-left: auto;
   margin-right: auto;

--- a/src/components/BasePage/BasePage.tsx
+++ b/src/components/BasePage/BasePage.tsx
@@ -2,7 +2,8 @@ import React, { PropsWithChildren } from "react";
 import NavBar from "../NavBar/navBar";
 import Footer from "../Footer/footer";
 import {
-  page as stylePage,
+  pageContainer as stylePageContainer,
+  pageArticle as stylePageArticle,
   header as styleHeader,
 } from "./BasePage.module.css";
 
@@ -11,16 +12,16 @@ interface BasePageProps extends PropsWithChildren {
 }
 
 const BasePage = ({ pageName, children }: BasePageProps) => (
-  <>
+  <div className={stylePageContainer}>
     <NavBar />
-    <div className={stylePage}>
+    <article className={stylePageArticle}>
       <header className={styleHeader}>
         <h1>{pageName}</h1>
       </header>
       <div>{children}</div>
-    </div>
+    </article>
     <Footer />
-  </>
+  </div>
 );
 
 export default BasePage;

--- a/src/components/Footer/footer.module.css
+++ b/src/components/Footer/footer.module.css
@@ -1,8 +1,6 @@
 .footer {
     background-color: #FF007f;
-    position: fixed;
     width: 100%;
-    bottom: 0;
     padding-top: 10px;
     padding-bottom: 10px;
     color: white;

--- a/src/components/Sponsor/sponsor.module.css
+++ b/src/components/Sponsor/sponsor.module.css
@@ -1,4 +1,18 @@
+.logoContainer {
+    flex: 1 1 auto;
+    display: flex;
+    align-items: center;
+}
+
 .logo {
     margin-bottom: 5px;
     padding: 5px;
+}
+
+.card {
+    height: 100%;
+}
+
+.cardBody {
+    flex: 0 1 auto;
 }

--- a/src/components/Sponsor/sponsor.tsx
+++ b/src/components/Sponsor/sponsor.tsx
@@ -1,22 +1,26 @@
 import React from "react";
+import Card from 'react-bootstrap/Card';
 import {
   logo as logoStyle
 } from "./sponsor.module.css"
 
 interface SponsorProps {
-    name: string;
-    logo: string;
-    style?: React.CSSProperties;
-  }
+  name: string;
+  logo: string;
+  description?: string;
+  style?: React.CSSProperties;
+}
 
-const Sponsor = ({ name, logo, style }: SponsorProps) => (
+const SponsorCard = ({name, logo, description, style}: SponsorProps) => (
   <>
-    <div className={logoStyle} >
-      <img src={logo} width="40%" style={style}>
-      </img>
-      <br/>
-    </div>
+    <Card>
+      <Card.Img variant="top" src={logo} style={style} className={logoStyle} />
+      <Card.Body>
+        <Card.Title>{name}</Card.Title>
+        <Card.Text>{description}</Card.Text>
+      </Card.Body>
+    </Card>
   </>
 );
 
-export default Sponsor;
+export {SponsorCard, SponsorProps};

--- a/src/components/Sponsor/sponsor.tsx
+++ b/src/components/Sponsor/sponsor.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import Card from 'react-bootstrap/Card';
 import {
-  logo as logoStyle
+  logo as logoStyle,
+  logoContainer as logoContainerStyle,
+  card as cardStyle,
+  cardBody as cardBodyStyle,
 } from "./sponsor.module.css"
 
 interface SponsorProps {
@@ -13,9 +16,12 @@ interface SponsorProps {
 
 const SponsorCard = ({name, logo, description, style}: SponsorProps) => (
   <>
-    <Card>
-      <Card.Img variant="top" src={logo} style={style} className={logoStyle} />
-      <Card.Body>
+    <Card className={cardStyle}>
+      <div className={logoContainerStyle} >
+        <Card.Img variant="top" src={logo} style={style} className={logoStyle}/>
+      </div>
+      
+      <Card.Body className={cardBodyStyle}>
         <Card.Title>{name}</Card.Title>
         <Card.Text>{description}</Card.Text>
       </Card.Body>

--- a/src/components/SponsorSection/sponsorSection.tsx
+++ b/src/components/SponsorSection/sponsorSection.tsx
@@ -22,6 +22,7 @@ interface SponsorSectionProps {
           </Col>
         ))}
       </Row>
+      <br/>
     </>
   );
 

--- a/src/components/SponsorSection/sponsorSection.tsx
+++ b/src/components/SponsorSection/sponsorSection.tsx
@@ -1,19 +1,27 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
+import Col from 'react-bootstrap/Col';
+import Row from 'react-bootstrap/Row';
+import { SponsorCard, SponsorProps } from "../../components/Sponsor/sponsor";
 
 
-interface SponsorSectionProps extends PropsWithChildren {
+interface SponsorSectionProps {
     title: string;
     color: string;
+    items: SponsorProps[];
   }
   
-  const SponsorSection = ({ title, color, children }: SponsorSectionProps) => (
+  const SponsorSection = ({ title, color, items }: SponsorSectionProps) => (
     <>
-      <div>
-        <header style={{color}}>
-          <h2>{title} Tier</h2>
-        </header>
-        <div>{children}</div>
-      </div>
+      <header style={{color}}>
+        <h2>{title} Tier</h2>
+      </header>
+      <Row xs={1} md={3} className="g-4 justify-content-center">
+        {items.map((val, idx) => (
+          <Col key={idx}>
+            <SponsorCard {...val}/>
+          </Col>
+        ))}
+      </Row>
     </>
   );
 

--- a/src/pages/sponsors.tsx
+++ b/src/pages/sponsors.tsx
@@ -23,7 +23,7 @@ const pinkSponsors = [
   {name:"Gene Haas Foundation", logo:logo_haas},
   {name:"Cherry Creek Schools Foundation", logo:logo_ccsf},
   {name:"Anglebotics", logo:logo_anglebotics, style: styles.anglebots},
-  {name:"ACE Hardware", logo:logo_ace},
+  {name:"ACE Hardware", logo:logo_ace, description: "Buckley Square"},
   {name:"Fastenal", logo:logo_fastenal},
   {name:"Brothers", logo:logo_brothers},
 ]

--- a/src/pages/sponsors.tsx
+++ b/src/pages/sponsors.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import BasePage from "../components/BasePage/BasePage";
 import SponsorSection from "../components/SponsorSection/sponsorSection";
-import Sponsor from "../components/Sponsor/sponsor";
 import logo_ccsd from "../images/logo_ccsd.png";
 import logo_comcast from "../images/logo_comcast.png";
 import logo_haas from "../images/logo_haas.png";
@@ -18,28 +17,27 @@ const styles = {
   }
 };
 
+const pinkSponsors = [
+  {name:"Cherry Creek School District", logo:logo_ccsd},
+  {name:"Comcast", logo:logo_comcast},
+  {name:"Gene Haas Foundation", logo:logo_haas},
+  {name:"Cherry Creek Schools Foundation", logo:logo_ccsf},
+  {name:"Anglebotics", logo:logo_anglebotics, style: styles.anglebots},
+  {name:"ACE Hardware", logo:logo_ace},
+  {name:"Fastenal", logo:logo_fastenal},
+  {name:"Brothers", logo:logo_brothers},
+]
+
+const silverSponsors = [
+  {name:"Harbor Freight Tools", logo:logo_harbor_freight},
+]
+
 const page = () => (
   <BasePage pageName="Current Sponsors">
-    <SponsorSection title="Pink" color="#FF007f">
-      <Sponsor name="Cherry Creek School District" logo={logo_ccsd}></Sponsor>
-      <Sponsor name="Comcast" logo={logo_comcast}></Sponsor>
-      <Sponsor name="Gene Haas Foundation" logo={logo_haas}></Sponsor>
-      <Sponsor name="Cherry Creek Schools Foundation" logo={logo_ccsf}></Sponsor>
-      <Sponsor name="Anglebotics" logo={logo_anglebotics} style={styles.anglebots}></Sponsor>
-      <Sponsor name="ACE Hardware" logo={logo_ace}></Sponsor>
-      <Sponsor name="Fastenal" logo={logo_fastenal}></Sponsor>
-      <Sponsor name="Brothers" logo={logo_brothers}></Sponsor>
-    </SponsorSection>
+    <SponsorSection title="Pink" items={pinkSponsors} color="#FF007f" />
     {/* <SponsorSection title="Gold" color="#ffd700"></SponsorSection> */}
-    <SponsorSection title="Silver" color="#c0c0c0"></SponsorSection>
-      <Sponsor name="Harbor Freight Tools" logo={logo_harbor_freight}></Sponsor>
+    <SponsorSection title="Silver" items={silverSponsors} color="#c0c0c0" />
     {/* <SponsorSection title="Bronze" color="#cd7f32"></SponsorSection> */}
-    <div>
-      <br />
-      <br />
-      <br />
-      <br />
-    </div>
   </BasePage>
 );
 


### PR DESCRIPTION
# What
- arrange sponsors in grid cards
- show specific ACE Hardware location
- footer doesn't cover content at bottom of page

# Why
- to organize sponsor names/extra details 
- to make more pretty

# Testing
- tested on localhost on different window sizes
    - Desktop: ![image](https://github.com/OHSBlazerbots/blazerbots/assets/6364480/eb1f8715-3e1a-49d9-92aa-009f02951629)
    - Phone: ![Screen Shot 2023-11-07 at 01 08 53](https://github.com/OHSBlazerbots/blazerbots/assets/6364480/2ee3a3fa-bcb4-4645-8a7d-534a2fa4236f)


