### PR TITLE
Fix: Navbar Styling issues

### DIFF
--- a/src/components/NavBar/navBar-static.css
+++ b/src/components/NavBar/navBar-static.css
@@ -1,0 +1,7 @@
+a.dropdown-toggle {
+  color: #ffffff;
+}
+
+a.dropdown-toggle:hover{
+  color: black;
+}

--- a/src/components/NavBar/navBar.module.css
+++ b/src/components/NavBar/navBar.module.css
@@ -22,14 +22,6 @@
   display: inline-block;
 }
 
-a.dropdown-toggle {
-  color: #ffffff;
-}
-
-a.dropdown-toggle:hover{
-  color: black;
-}
-
 .linkActive {
   color:  black;
 }

--- a/src/components/NavBar/navBar.module.css
+++ b/src/components/NavBar/navBar.module.css
@@ -17,7 +17,6 @@
 
 .dropDefault {
   color: #FF007f;
-  text-align: center;
   text-decoration: none;
   display: inline-block;
 }

--- a/src/components/NavBar/navBar.tsx
+++ b/src/components/NavBar/navBar.tsx
@@ -12,6 +12,17 @@ import "./navBar-static.css";
 
 const stopClickPropagation:React.MouseEventHandler = event => event.stopPropagation();
 
+const DropdownItem = NavDropdown.Item; // alias so less typing
+const DropdownItemProps = {
+  as: Link,
+  className: dropDefault,
+  activeClassName: linkActive,
+};
+const ExternalLinkProps = {
+  className: dropDefault,
+  onClick: stopClickPropagation,
+};
+
 function NavBar() {
   return ( 
     <Navbar className={navBackground} expand="lg" variant="dark">
@@ -33,17 +44,15 @@ function NavBar() {
           <Nav className="navbar" >
             <Link to="/about-us" className={linkDefault} activeClassName={linkActive} >About Us</Link>
             <NavDropdown title="Sponsors">
-              <NavDropdown.Item as={Link} to="/sponsors" className={dropDefault} activeClassName={linkActive}>Current Sponsors</NavDropdown.Item>
-              <NavDropdown.Item as={Link} to="/how-to-be-sponsors" className={dropDefault} activeClassName={linkActive}>Become a Sponsor</NavDropdown.Item>
+              <DropdownItem {...DropdownItemProps} to="/sponsors">Current Sponsors</DropdownItem>
+              <DropdownItem {...DropdownItemProps} to="/how-to-be-sponsors">Become a Sponsor</DropdownItem>
             </NavDropdown>
             <NavDropdown title="The Team">
-              <NavDropdown.Item as={Link} to="/about-us" className={dropDefault} activeClassName={linkActive}>Meet the team</NavDropdown.Item>
-              <NavDropdown.Item as={Link} to="/history" className={dropDefault} activeClassName={linkActive}>Competitions</NavDropdown.Item>
-              <NavDropdown.Item as={Link} to="/calendar" className={dropDefault} activeClassName={linkActive}>Calendar</NavDropdown.Item>
+              <DropdownItem {...DropdownItemProps} to="/about-us">Meet the team</DropdownItem>
+              <DropdownItem {...DropdownItemProps} to="/history">Competitions</DropdownItem>
+              <DropdownItem {...DropdownItemProps} to="/calendar">Calendar</DropdownItem>
               <NavDropdown.Divider />
-              <NavDropdown.Item>
-                <a href="https://www.firstinspires.org/robotics/frc" className={dropDefault} onClick={stopClickPropagation} >FIRST</a>
-              </NavDropdown.Item>
+              <DropdownItem {...ExternalLinkProps} href="https://www.firstinspires.org/robotics/frc">FIRST</DropdownItem>
             </NavDropdown>
             <Link to="/resources" className={linkDefault} activeClassName={linkActive} >Resources</Link>
           </Nav>

--- a/src/components/NavBar/navBar.tsx
+++ b/src/components/NavBar/navBar.tsx
@@ -7,6 +7,9 @@ import blackLogo from "../../images/logo192_black.png";
 import { Link } from "gatsby";
 import { navBackground, linkDefault, linkActive, linkNavBrand, dropDefault } from './navBar.module.css';
 
+// Not using a CSS module because we want to globally modify class names from Bootstrap
+import "./navBar-static.css";
+
 const stopClickPropagation:React.MouseEventHandler = event => event.stopPropagation();
 
 function NavBar() {
@@ -27,7 +30,7 @@ function NavBar() {
         </Link>
         <Navbar.Toggle aria-controls="basic-navbar-nav" />
         <Navbar.Collapse id="basic-navbar-nav" className="justify-content-end">
-          <Nav className="navbar navbar-light" >
+          <Nav className="navbar" >
             <Link to="/about-us" className={linkDefault} activeClassName={linkActive} >About Us</Link>
             <NavDropdown title="Sponsors">
               <NavDropdown.Item>

--- a/src/components/NavBar/navBar.tsx
+++ b/src/components/NavBar/navBar.tsx
@@ -33,23 +33,13 @@ function NavBar() {
           <Nav className="navbar" >
             <Link to="/about-us" className={linkDefault} activeClassName={linkActive} >About Us</Link>
             <NavDropdown title="Sponsors">
-              <NavDropdown.Item>
-                <Link to="/sponsors" className={dropDefault} activeClassName={linkActive} > Current Sponsors</Link>
-              </NavDropdown.Item>
-              <NavDropdown.Item>
-                <Link to="/how-to-be-sponsors" className={dropDefault} activeClassName={linkActive} > Become a Sponsor</Link>
-              </NavDropdown.Item>
+              <NavDropdown.Item as={Link} to="/sponsors" className={dropDefault} activeClassName={linkActive}>Current Sponsors</NavDropdown.Item>
+              <NavDropdown.Item as={Link} to="/how-to-be-sponsors" className={dropDefault} activeClassName={linkActive}>Become a Sponsor</NavDropdown.Item>
             </NavDropdown>
             <NavDropdown title="The Team">
-              <NavDropdown.Item>
-                <Link to="/about-us" className={dropDefault} activeClassName={linkActive} >Meet the team</Link>
-              </NavDropdown.Item>
-              <NavDropdown.Item>
-                <Link to="/history" className={dropDefault} activeClassName={linkActive} >Competitions</Link>
-              </NavDropdown.Item>
-              <NavDropdown.Item>
-                <Link to="/calendar" className={dropDefault} activeClassName={linkActive} >Calendar</Link>
-              </NavDropdown.Item>
+              <NavDropdown.Item as={Link} to="/about-us" className={dropDefault} activeClassName={linkActive}>Meet the team</NavDropdown.Item>
+              <NavDropdown.Item as={Link} to="/history" className={dropDefault} activeClassName={linkActive}>Competitions</NavDropdown.Item>
+              <NavDropdown.Item as={Link} to="/calendar" className={dropDefault} activeClassName={linkActive}>Calendar</NavDropdown.Item>
               <NavDropdown.Divider />
               <NavDropdown.Item>
                 <a href="https://www.firstinspires.org/robotics/frc" className={dropDefault} onClick={stopClickPropagation} >FIRST</a>

--- a/src/pages/how-to-be-sponsors.tsx
+++ b/src/pages/how-to-be-sponsors.tsx
@@ -8,8 +8,8 @@ const title = "Become a Sponsor"
 const sponsorPacketUrl = "https://drive.google.com/file/d/1zJ_RThOwgtSONbEUVSGEswerpjsNMbjc/preview";
 
 const style = {
-  "margin": "auto",
-}
+  margin: "auto",
+};
 
 const makeSponsorTierText = (tier: keyof typeof SponsorTiers) => {
   // Lookup color associated with sponsorship tier
@@ -17,8 +17,8 @@ const makeSponsorTierText = (tier: keyof typeof SponsorTiers) => {
   
   const tierStyle = {
     color: tierColor,
-    "font-weight": "bold"
-  }
+    fontWeight: "bold"
+  };
 
   return (
     <span style={tierStyle}>{tier}</span>
@@ -27,10 +27,10 @@ const makeSponsorTierText = (tier: keyof typeof SponsorTiers) => {
 
 
 const pdfContainerStyle = {
-  "aspect-ratio": "8.5/11",
+  aspectRatio: "8.5/11",
   width: "80%",
   margin: "auto",
-}
+};
 
 const page = () => (
   <BasePage pageName={title}>


### PR DESCRIPTION
# What
- First level links on navbar are all white by default, and black on hover (previously the dropdown elements had black/gray text)
- In dropdown, entire `Dropdown.Item` is link (previously only the text in blue was the link)

# Why
- To make the navbar design more consistent and easier to navigate

# Testing
See screenshots
## Dropdowns closed:
- Before: ![Screenshot from 2023-11-29 17-09-08](https://github.com/OHSBlazerbots/blazerbots/assets/6364480/ddcdfdfb-7c72-4f79-bddc-5895d59c0cb0)
- After: ![Screenshot from 2023-11-29 17-09-01](https://github.com/OHSBlazerbots/blazerbots/assets/6364480/f874f0c6-65a5-4aed-acec-7a4ab381431f)

## Dropdown open:
- Before: ![Screenshot from 2023-11-29 17-00-01](https://github.com/OHSBlazerbots/blazerbots/assets/6364480/3d08cd31-7c04-4938-a0b3-e4f843b56bd3)
- After: ![Screenshot from 2023-11-29 17-00-13](https://github.com/OHSBlazerbots/blazerbots/assets/6364480/4f91acee-8e67-47de-8fbe-88c4921c9af8)
