### PR TITLE
Fix: mentor cards on iOS

### DIFF
--- a/src/components/MentorCard/mentorCard.module.css
+++ b/src/components/MentorCard/mentorCard.module.css
@@ -14,7 +14,7 @@
 .card {
   border: 5px dashed #ff007f;
   max-height: 100%;
-  overflow: auto;
+  overflow: clip;
 }
 
 .card:hover {


### PR DESCRIPTION
# What

- fix: This fixes an issue with backside of mentor cards being visible in iOS mobile browsers

# Why

- to improve UI

# Testing

- I tested Firefox iOS, chromium desktop, Firefox desktop

## Screen shots:

None I'm posting PR from mobile.