### PR TITLE
Add link to store

### DIFF
--- a/src/components/NavBar/navBar.tsx
+++ b/src/components/NavBar/navBar.tsx
@@ -51,6 +51,7 @@ function NavBar() {
               <DropdownItem {...ExternalLinkProps} href="https://www.firstinspires.org/robotics/frc">FIRST</DropdownItem>
             </NavDropdown>
             <Link to="/resources" className={linkDefault} activeClassName={linkActive} >Resources</Link>
+            <Link to="https://overland-robotics.square.site/" className={linkDefault} >Store</Link>
           </Nav>
         </Navbar.Collapse>
       </Container>


### PR DESCRIPTION
# What

- Add link to square store

# Why

- To raise awareness of our team store for the craft fair

# Testing

- Tested locally, opens the store in the same tab

## Screen shots:

<details>
    <summary>Desktop</summary>
    <img alt="mobile screenshot" src="https://github.com/user-attachments/assets/6d044bc5-a394-472f-85e8-bcd86441504a"/>
</details>

<details>
    <summary>Mobile</summary>
    <img alt="mobile screenshot" src="https://github.com/user-attachments/assets/4d5e3861-e27f-42dd-bbc6-5d4da5dece24"/>
</details>
