### PR TITLE
Update actions/upload-pages-artifact to v3

### DIFF
--- a/.github/workflows/gatsby-deploy.yml
+++ b/.github/workflows/gatsby-deploy.yml
@@ -80,7 +80,7 @@ jobs:
           PREFIX_PATHS: "true"
         run: ${{ steps.detect-package-manager.outputs.manager }} run build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
 


### PR DESCRIPTION
# What

The previous deploy failed because of an outdated/yanked action: https://github.com/OHSBlazerbots/blazerbots/actions/runs/14284084928

This updates the action.

# Why

So builds work!

# Testing

We'll find out when this is merged!

## Screen shots:

No website changes!
